### PR TITLE
Video additional indexes

### DIFF
--- a/graphai/core/common/caching.py
+++ b/graphai/core/common/caching.py
@@ -608,8 +608,7 @@ class VideoDBCachingManager(DBCachingManagerBase):
                 CREATE INDEX `video_main_origin_token_index` ON `{self.schema}`.`{self.cache_table}` (`origin_token`(512));
                 """
             )
-        except Exception as e:
-            print(e)
+        except Exception:
             pass
 
         # Creating the closest match table


### PR DESCRIPTION
Adds indexes for the `origin_token` column in the video, audio, and image cache tables. This will speed up the lookup of cached results for `/retrieve_url`, `/extract_audio`, and `/detect_slides` endpoints.