### PR TITLE
Force recomputation fix

### DIFF
--- a/graphai/api/celery_tasks/video.py
+++ b/graphai/api/celery_tasks/video.py
@@ -311,6 +311,7 @@ def extract_and_sample_frames_task(self, token, force=False):
                             'fresh': False,
                             'slide_tokens': None
                         }
+                    # If everything's fine, we delete the cache rows before continuing
                     slide_db_manager.delete_cache_rows([x['id_token'] for x in existing_slides])
                     # We break because we're done with the cache lookup
                     break


### PR DESCRIPTION
For most endpoints, calling the endpoint with the `force` flag on for a token whose file has been deleted (e.g. to preserve disk space) would only cause an unsuccessful computation.

However, `/video/detect_slides` with the `force` flag on deletes the corresponding cache rows (cache rows where `origin_token` is the provided token), since `detect_slides` is the only operation where an operation on one row (in the video cache table) leads to the creation of several rows (in the slide cache table). If the corresponding file has already been deleted from the cache, then we are left with no way to replace the deleted cache rows.

This pull request adds a fix for this issue, where we check for the existence of the original video token before we delete the cache rows. This makes the behavior of all endpoints with `force=True` consistent: try to compute from scratch, fail if the file doesn't exist, do not modify anything in the cache in case of failure.