### PR TITLE
force the inclusion of the first slide

### DIFF
--- a/graphai/api/celery_tasks/video.py
+++ b/graphai/api/celery_tasks/video.py
@@ -462,6 +462,8 @@ def compute_slide_transitions_callback_task(self, results):
 
     list_of_slide_transition_lists = [x['transitions'] for x in results]
     all_transitions = list(chain.from_iterable(list_of_slide_transition_lists))
+    # Making sure there are no duplicates
+    all_transitions = sorted(list(set(all_transitions)))
 
     return {
         'result': results[0]['result'],

--- a/graphai/core/common/video.py
+++ b/graphai/core/common/video.py
@@ -873,7 +873,7 @@ def compute_video_ocr_transitions(input_folder_with_path, frame_sample_indices, 
     Returns:
         List of transitory slides
     """
-    transition_list = list()
+    transition_list = [frame_sample_indices[0]]
     for k in range(1, len(frame_sample_indices)):
         [t, d] = frame_ocr_transition(
             input_folder_with_path,
@@ -886,6 +886,9 @@ def compute_video_ocr_transitions(input_folder_with_path, frame_sample_indices, 
         )
         if t is not None and t < frame_sample_indices[-1]:
             transition_list.append(t)
+    # Making sure the first and second elements are not the same
+    if len(transition_list) >= 2 and transition_list[0] == transition_list[1]:
+        transition_list = transition_list[1:]
     return transition_list
 
 


### PR DESCRIPTION
Resolves issue #84 by forcing the inclusion of the first slide in the slide detection algorithm. After all the slides are pooled together, we make sure there are no direct duplicates. This will result in the inclusion of the first slide of every slice that we process in parallel (which is currently 8 slices).