### PR TITLE
fix no frame indices bug

### DIFF
--- a/graphai/core/common/video.py
+++ b/graphai/core/common/video.py
@@ -873,6 +873,8 @@ def compute_video_ocr_transitions(input_folder_with_path, frame_sample_indices, 
     Returns:
         List of transitory slides
     """
+    if len(frame_sample_indices) == 0:
+        return list()
     transition_list = [frame_sample_indices[0]]
     for k in range(1, len(frame_sample_indices)):
         [t, d] = frame_ocr_transition(


### PR DESCRIPTION
Fixes a bug newly introduced where the slide detection function expected the sample frame indices list to be at least of length 1. After this fix, the list can be empty and no errors will occur.