### PR TITLE
enable flower api without authentication

### DIFF
--- a/graphai/api/deploy_celery.sh
+++ b/graphai/api/deploy_celery.sh
@@ -2,4 +2,4 @@
 
 nice -n 0 celery -A main.celery_instance worker --hostname workerHigh@%h -l debug -P threads --prefetch-multiplier 20 -c 16 -Q text_10 -D
 nice -n 20 celery -A main.celery_instance worker --hostname workerLow@%h -l debug -P threads --prefetch-multiplier 1 -c 16 -Q celery,video_2,ontology_6,text_6 -D
-celery -A main.celery_instance flower --port=5555
+FLOWER_UNAUTHENTICATED_API=true celery -A main.celery_instance flower --port=5555


### PR DESCRIPTION
Enables unauthenticated calls to Flower API in order to facilitate debugging on RCP cluster server.