### PR TITLE
:bug: fix bug when normalising text containing < ! [

### DIFF
--- a/graphai/core/utils/text/clean.py
+++ b/graphai/core/utils/text/clean.py
@@ -140,6 +140,9 @@ def normalize(text):
     # Clean text of encoding problems and other rubbish
     text = ct.clean(text, lower=False, to_ascii=False, no_line_breaks=False, no_urls=True, replace_with_url='', no_emails=True, replace_with_email='')
 
+    # Remove patterns known to create issues with HTMLCleaner
+    text = text.replace('<![', '[')
+
     # Clean text of HTML code
     c = HTMLCleaner()
     c.feed(text)


### PR DESCRIPTION
Fixes an odd bug that makes HTMLCleaner crash when fed a pattern like `<![`. Now we just replace that by `[`.