### PR TITLE
Spawn instead of fork

### DIFF
--- a/graphai/core/interfaces/celery_config.py
+++ b/graphai/core/interfaces/celery_config.py
@@ -74,6 +74,10 @@ def create_celery():
     Returns:
         Celery app object
     """
+    os.environ["FORKED_BY_MULTIPROCESSING"] = "1"
+    if os.name != "nt":
+        from billiard import context
+        context._force_start_method("spawn")
     celery_app = current_celery_app
     settings = get_settings()
     celery_app.config_from_object(settings, namespace='CELERY')


### PR DESCRIPTION
Adds a line before the creation of the celery object in order to force the worker to spawn processes instead of forking them. Necessary on Unix (more generally on POSIX, but MacOS has safeguards against forking) in order to safely use thread-unsafe packages like `requests` that may encounter bugs if the Python process is forked.