### PR TITLE
:sparkles: accept keyword list as input for wikify

### DIFF
--- a/graphai/api/celery_tasks/text.py
+++ b/graphai/api/celery_tasks/text.py
@@ -26,12 +26,15 @@ def extract_keywords_task(self, raw_text, use_nltk=False):
     Celery task that extracts keywords from a given text.
 
     Args:
-        raw_text (str): Text to extract keywords from.
+        raw_text (str|list): Text to extract keywords from. If a list is passed, it is assumed that they are the keywords and the same list is returned.
         use_nltk (bool): Whether to use nltk-rake for keyword extraction, otherwise python-rake is used. Default: False.
 
     Returns:
         list[str]: A list containing the keywords extracted from the text.
     """
+
+    if isinstance(raw_text, list):
+        return raw_text
 
     keywords_list = get_keywords(raw_text, use_nltk)
 

--- a/graphai/api/schemas/text.py
+++ b/graphai/api/schemas/text.py
@@ -2,15 +2,27 @@ from pydantic import BaseModel, Field
 from typing import List
 
 
-class WikifyRequest(BaseModel):
+class WikifyFromRawTextRequest(BaseModel):
     """
-    Object containing the information to be wikified and the list of anchor page ids to define the search space in the graph.
+    Object containing the raw text to be wikified.
     """
     raw_text: str = Field(
         ...,
         title="Raw Text",
         description="Raw text to be wikified",
         example="To draw a straight line from any point to any point.\nTo produce a finite straight line continuously in a straight line.\nTo describe a circle with any center and radius.\nThat all right angles equal one another.\nThat, if a straight line falling on two straight lines makes the interior angles on the same side less than two right angles, the two straight lines, if produced indefinitely, meet on that side on which are the angles less than the two right angles."
+    )
+
+
+class WikifyFromKeywordsRequest(BaseModel):
+    """
+    Object containing the keywords to be wikified.
+    """
+    keywords: list[str] = Field(
+        ...,
+        title="Keywords",
+        description="List of keywords to be wikified",
+        example=["straight line", "point to point", "describe a circle", "all right angles equal", "two straight lines", "interior angles", "less than two right angles"],
     )
 
 

--- a/tests/fixtures/text.py
+++ b/tests/fixtures/text.py
@@ -25,6 +25,11 @@ def schreier():
 
 
 @pytest.fixture
+def euclid():
+    return ["straight line", "point to point", "describe a circle", "all right angles equal", "two straight lines", "interior angles", "less than two right angles"]
+
+
+@pytest.fixture
 def wave_fields_wikisearch_df():
     return pd.DataFrame([
         ['acoustic wave fields', 1901541, """Ion_acoustic_wave""", 1, 1, 0.848181],

--- a/tests/test_text.py
+++ b/tests/test_text.py
@@ -280,7 +280,7 @@ def test__text_keywords__aggregate__run_task(wave_fields_scores_df):
 
 @pytest.mark.celery(accept_content=['pickle', 'json'], result_serializer='pickle', task_serializer='pickle')
 @pytest.mark.usefixtures('wave_fields', 'schreier')
-def test__text_wikify__integration(fixture_app, celery_worker, wave_fields, schreier, timeout=60):
+def test__text_wikify__integration(fixture_app, celery_worker, euclid, wave_fields, schreier, timeout=60):
     # Make POST request to fixture fastapi app
     response = fixture_app.post('/text/wikify', data=json.dumps({'raw_text': ''}), timeout=timeout)
 
@@ -293,6 +293,24 @@ def test__text_wikify__integration(fixture_app, celery_worker, wave_fields, schr
     # Check returned value
     assert isinstance(results, pd.DataFrame)
     assert len(results) == 0
+
+    ################
+
+    # Make POST request to fixture fastapi app
+    response = fixture_app.post('/text/wikify', data=json.dumps({'keywords': euclid}), timeout=timeout)
+
+    # Check status code is successful
+    assert response.status_code == 200
+
+    # Parse result
+    results = pd.DataFrame(response.json())
+
+    # Check returned value
+    assert isinstance(results, pd.DataFrame)
+    assert len(results) > 0
+    assert 1196 in results['PageID'].values        # Angle wikipage
+    for column in ['PageID', 'PageTitle', 'SearchScore', 'LevenshteinScore', 'GraphScore', 'OntologyLocalScore', 'OntologyGlobalScore', 'KeywordsScore', 'MixedScore']:
+        assert column in results.columns
 
     ################
 


### PR DESCRIPTION
Now wikify also accepts a list of `keywords` as input (instead of `raw_text`). In particular, it accepts the following as input:
```
{
"keywords": ["straight line", "point to point", "describe a circle", "all right angles equal", "two straight lines", "interior angles", "less than two right angles"]
}
```