### PR TITLE
make parent and child ids strings

### DIFF
--- a/graphai/api/ontology/schemas.py
+++ b/graphai/api/ontology/schemas.py
@@ -9,13 +9,13 @@ class TreeResponseElem(BaseModel):
     Object representing the output of the /ontology/tree endpoint.
     """
 
-    child_id: int = Field(
+    child_id: str = Field(
         ...,
         title="Child category ID",
         description="ID of the child category"
     )
 
-    parent_id: int = Field(
+    parent_id: str = Field(
         ...,
         title="Parent category ID",
         description="ID of the parent category"


### PR DESCRIPTION
Fix issue with `/ontology/tree` endpoint where the parent and child ids in the response were `int` instead of `str` for whatever reason