### PR TITLE
Auto date filter

### DIFF
--- a/graphai/api/retrieval/router.py
+++ b/graphai/api/retrieval/router.py
@@ -43,9 +43,10 @@ async def retrieve_from_es_index(data: RetrievalRequest,
     limit = data.limit
     index_to_search_in = data.index
     return_scores = data.return_scores
+    filter_by_date = data.filter_by_date
     if not has_rag_access_rights(current_user.username, index_to_search_in):
         return INSUFFICIENT_ACCESS_ERROR
-    results = retrieve_from_es_job(text, index_to_search_in, filters, limit, return_scores)
+    results = retrieve_from_es_job(text, index_to_search_in, filters, limit, return_scores, filter_by_date)
     return results
 
 

--- a/graphai/api/retrieval/schemas.py
+++ b/graphai/api/retrieval/schemas.py
@@ -31,6 +31,16 @@ class RetrievalRequest(BaseModel):
         default=False
     )
 
+    filter_by_date: bool = Field(
+        title="Filter by current date",
+        description="If True, if the requested index has 'from' and 'until' fields, only returns documents "
+                    "that are available at the current date and time based on those two fields. Basically "
+                    "a smart custom filter that doesn't require the user to manually provide the current "
+                    "datetime and ask for 'from' to be before it and for 'until' to be after it. "
+                    "If the index does not have 'from' and 'until' fields, this results in an empty response.",
+        default=False
+    )
+
 
 class RetrievalResponse(BaseModel):
     n_results: int = Field(

--- a/graphai/celery/retrieval/jobs.py
+++ b/graphai/celery/retrieval/jobs.py
@@ -9,10 +9,11 @@ from graphai.core.retrieval.retrieval_settings import RETRIEVAL_PARAMS
 from graphai.celery.common.jobs import DEFAULT_TIMEOUT
 
 
-def retrieve_from_es_job(text, index_to_search_in, filters=None, limit=10, return_scores=False):
+def retrieve_from_es_job(text, index_to_search_in,
+                         filters=None, limit=10, return_scores=False, filter_by_date=False):
     task_list = [
         embed_text_task.s(text, RETRIEVAL_PARAMS.get(index_to_search_in, dict()).get('model', None)),
-        retrieve_from_es_task.s(text, index_to_search_in, filters, limit, return_scores)
+        retrieve_from_es_task.s(text, index_to_search_in, filters, limit, return_scores, filter_by_date)
     ]
     task = chain(task_list)
     results = task.apply_async(priority=6).get(timeout=DEFAULT_TIMEOUT)

--- a/graphai/celery/retrieval/tasks.py
+++ b/graphai/celery/retrieval/tasks.py
@@ -15,8 +15,9 @@ anonymizer_model = AnonymizerModels()
 @shared_task(bind=True, autoretry_for=(Exception,), retry_backoff=True, retry_kwargs={"max_retries": 2},
              name='retrieval_10.retrieve', ignore_result=False)
 def retrieve_from_es_task(self, embedding_results, text, index_to_search_in,
-                          filters=None, limit=10, return_scores=False):
-    return retrieve_from_es(embedding_results, text, index_to_search_in, filters, limit, return_scores)
+                          filters=None, limit=10, return_scores=False, filter_by_date=False):
+    return retrieve_from_es(embedding_results, text, index_to_search_in,
+                            filters, limit, return_scores, filter_by_date)
 
 
 @shared_task(bind=True, autoretry_for=(Exception,), retry_backoff=True, retry_kwargs={"max_retries": 2},

--- a/graphai/core/retrieval/retrieval_utils.py
+++ b/graphai/core/retrieval/retrieval_utils.py
@@ -62,9 +62,10 @@ def retrieve_from_es(embedding_results, text, index_to_search_in,
     if filters is None:
         filters = dict()
     if filter_by_date:
+        right_now = datetime.now().isoformat()
         filters = filters | {
-            'from_date': {'lte': datetime.now().isoformat()},
-            'until_date': {'gte': datetime.now().isoformat()}
+            'from_date': {'lte': right_now},
+            'until_date': {'gte': right_now}
         }
     if index_to_search_in in RETRIEVAL_PARAMS.keys():
         return search_es_index(

--- a/graphai/core/retrieval/retrieval_utils.py
+++ b/graphai/core/retrieval/retrieval_utils.py
@@ -1,3 +1,4 @@
+from datetime import datetime
 from graphai.core.common.config import config
 from graphai.core.retrieval.retrieval_settings import RETRIEVAL_PARAMS
 from langchain_text_splitters import RecursiveCharacterTextSplitter
@@ -56,9 +57,15 @@ def search_es_index(retriever_type,
         }
 
 
-def retrieve_from_es(embedding_results, text, index_to_search_in, filters=None, limit=10, return_scores=False):
+def retrieve_from_es(embedding_results, text, index_to_search_in,
+                     filters=None, limit=10, return_scores=False, filter_by_date=False):
     if filters is None:
         filters = dict()
+    if filter_by_date:
+        filters = filters | {
+            'from_date': {'lte': datetime.now().isoformat()},
+            'until_date': {'gte': datetime.now().isoformat()}
+        }
     if index_to_search_in in RETRIEVAL_PARAMS.keys():
         return search_es_index(
             retriever_type=RETRIEVAL_PARAMS[index_to_search_in]['retrieval_class'],

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,7 +62,7 @@ dependencies = [
     "sphinx-rtd-theme",
     "pytest-celery",
     "db-cache-manager>=0.2.2",
-    "elasticsearch-interface>=0.11.1",
+    "elasticsearch-interface>=1.2.0",
     "scikit-learn",
     "opentelemetry-distro==0.40b0",
     "opentelemetry-exporter-otlp==1.19.0",


### PR DESCRIPTION
Adds an automatic date filter to the `/rag/retrieve` endpoint that is disabled by default. Once enabled, it requires the date fields `from` and `until` to fall on the two sides of the current date and time.