### PR TITLE
add one_chunk_per_doc option

### DIFF
--- a/graphai/api/retrieval/router.py
+++ b/graphai/api/retrieval/router.py
@@ -96,7 +96,8 @@ async def chunk_text(data: ChunkRequest):
     chunk_size = data.chunk_size
     chunk_overlap = data.chunk_overlap
     one_chunk_per_page = data.one_chunk_per_page
-    return chunk_text_job(text, chunk_size, chunk_overlap, one_chunk_per_page)
+    one_chunk_per_doc = data.one_chunk_per_doc
+    return chunk_text_job(text, chunk_size, chunk_overlap, one_chunk_per_page, one_chunk_per_doc)
 
 
 @router.post('/anonymize', response_model=AnonymizeResponse,

--- a/graphai/api/retrieval/schemas.py
+++ b/graphai/api/retrieval/schemas.py
@@ -97,6 +97,11 @@ class ChunkRequest(BaseModel):
         default=False
     )
 
+    one_chunk_per_doc: bool = Field(
+        title="One chunk for the whole document. Overrides one_chunk_per_page if True.",
+        default=False
+    )
+
 
 class ChunkResponse(BaseModel):
     split: List[str] = Field(

--- a/graphai/celery/retrieval/jobs.py
+++ b/graphai/celery/retrieval/jobs.py
@@ -20,8 +20,8 @@ def retrieve_from_es_job(text, index_to_search_in,
     return results
 
 
-def chunk_text_job(text, chunk_size, chunk_overlap, one_chunk_per_page=False):
-    task = chunk_text_task.s(text, chunk_size, chunk_overlap, one_chunk_per_page)
+def chunk_text_job(text, chunk_size, chunk_overlap, one_chunk_per_page=False, one_chunk_per_doc=False):
+    task = chunk_text_task.s(text, chunk_size, chunk_overlap, one_chunk_per_page, one_chunk_per_doc)
     results = task.apply_async(priority=10).get(timeout=DEFAULT_TIMEOUT)
     return results
 

--- a/graphai/celery/retrieval/tasks.py
+++ b/graphai/celery/retrieval/tasks.py
@@ -22,8 +22,9 @@ def retrieve_from_es_task(self, embedding_results, text, index_to_search_in,
 
 @shared_task(bind=True, autoretry_for=(Exception,), retry_backoff=True, retry_kwargs={"max_retries": 2},
              name='retrieval_10.chunk', ignore_result=False)
-def chunk_text_task(self, text, chunk_size=400, chunk_overlap=100, one_chunk_per_page=False):
-    return chunk_text(text, chunk_size, chunk_overlap, one_chunk_per_page)
+def chunk_text_task(self, text, chunk_size=400, chunk_overlap=100,
+                    one_chunk_per_page=False, one_chunk_per_doc=False):
+    return chunk_text(text, chunk_size, chunk_overlap, one_chunk_per_page, one_chunk_per_doc)
 
 
 @shared_task(bind=True, autoretry_for=(Exception,), retry_backoff=True, retry_kwargs={"max_retries": 2},

--- a/graphai/core/retrieval/retrieval_utils.py
+++ b/graphai/core/retrieval/retrieval_utils.py
@@ -102,7 +102,8 @@ def retrieve_from_es(embedding_results, text, index_to_search_in,
         )
 
 
-def chunk_text(text, chunk_size=400, chunk_overlap=100, one_chunk_per_page=False):
+def chunk_text(text, chunk_size=400, chunk_overlap=100,
+               one_chunk_per_page=False, one_chunk_per_doc=False):
     # text can be a string or an int to str dict
     if isinstance(text, str):
         keys = None
@@ -111,7 +112,9 @@ def chunk_text(text, chunk_size=400, chunk_overlap=100, one_chunk_per_page=False
         text = {int(k): text[k] for k in text}
         keys = sorted(list(text.keys()))
         full_content = ' '.join(text[k] for k in keys)
-    if one_chunk_per_page and keys is not None:
+    if one_chunk_per_doc:
+        split_content = [full_content]
+    elif one_chunk_per_page and keys is not None:
         # If 1 chunk/page is enabled but the original text is one block with no pages, we can't do 1 chunk/page
         split_content = [text[k] for k in keys]
     else:


### PR DESCRIPTION
Add one chunk per doc option for the `/rag/chunk_text` endpoint