### PR TITLE
Ocr class refactor

### DIFF
--- a/graphai/celery/video/jobs.py
+++ b/graphai/celery/video/jobs.py
@@ -271,8 +271,8 @@ def detect_slides_job(token, language, force=False, recalculate_cached=False, **
                           i,
                           n_jobs,
                           language,
-                          kwargs.get('include_first', True),
-                          kwargs.get('include_last', True)
+                          True if i > 0 else kwargs.get('include_first', True),
+                          True if i < n_jobs - 1 else kwargs.get('include_last', True)
                       ) for i in range(n_jobs)),
                       compute_slide_transitions_callback_task.s(language),
                       detect_slides_callback_task.s(token, force)]

--- a/graphai/core/image/ocr.py
+++ b/graphai/core/image/ocr.py
@@ -136,7 +136,7 @@ class GoogleOCRModel(AbstractOCRModel):
             client_options={"api_key": self.api_key}
         )
 
-    def perform_ocr(self, input_filename_with_path):
+    def perform_ocr(self, input_filename_with_path, **kwargs):
         """
         Performs OCR with two methods (text_detection and document_text_detection)
         Args:

--- a/graphai/core/retrieval/retrieval_settings.py
+++ b/graphai/core/retrieval/retrieval_settings.py
@@ -6,28 +6,28 @@ from elasticsearch_interface.es import (
 
 RETRIEVAL_PARAMS = dict()
 RETRIEVAL_PARAMS["lex"] = {
-    "default_index": "ramtin_lex_index",
+    "default_index": "rag_lex_index",
     "retrieval_class": ESLex,
     "model": "all-MiniLM-L12-v2",
     "filters": ["lang"]
 }
 
 RETRIEVAL_PARAMS["servicedesk"] = {
-    "default_index": "ramtin_servicedesk_index",
+    "default_index": "rag_servicedesk_index",
     "retrieval_class": ESServiceDesk,
     "model": "all-MiniLM-L12-v2",
     "filters": ["lang", "category"]
 }
 
 RETRIEVAL_PARAMS["sac"] = {
-    "default_index": "ramtin_sac_index",
+    "default_index": "rag_sac_index",
     "retrieval_class": ESLex,
     "model": "all-MiniLM-L12-v2",
     "filters": ["lang"]
 }
 
 RETRIEVAL_PARAMS["default"] = {
-    "default_index": "ramtin_%s_index",
+    "default_index": "rag_%s_index",
     "retrieval_class": ESGeneralRAG,
     "model": "all-MiniLM-L12-v2",
     "filters": None

--- a/graphai/core/video/video_utils.py
+++ b/graphai/core/video/video_utils.py
@@ -569,8 +569,8 @@ def check_ocr_and_hash_thresholds(input_folder_with_path, k_l, k_r,
                                   language=None):
     d = float(frame_ocr_distance(input_folder_with_path, k_l, k_r, nlp_models, language))
     s_hash = float(frame_hash_similarity(input_folder_with_path, k_l, k_r))
-    ocr_dist_pass = d > ocr_dist_threshold
-    hash_sim_pass = s_hash < hash_similarity_threshold
+    ocr_dist_pass = d >= ocr_dist_threshold
+    hash_sim_pass = s_hash <= hash_similarity_threshold
     return (ocr_dist_pass and hash_sim_pass), d, s_hash
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,7 +62,7 @@ dependencies = [
     "sphinx-rtd-theme",
     "pytest-celery",
     "db-cache-manager>=0.2.2",
-    "elasticsearch-interface>=1.2.0",
+    "elasticsearch-interface>=1.3.0",
     "scikit-learn",
     "opentelemetry-distro==0.40b0",
     "opentelemetry-exporter-otlp==1.19.0",


### PR DESCRIPTION
* Adds the possibility of bypassing OCR and hash-based difference calculations in slide detection (not recommended unless you know what you're doing!)
* Makes sure `include_first` and `include_last` flags only apply to the entire video, not each chunk during processing.
* Uses latest version of elasticsearch-interface so that date range filters are applied correctly for null values
* Changes RAG index names
* Fixes a few code quality issues