### PR TITLE
bump elasticsearch-interface version to 1.3.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,7 +62,7 @@ dependencies = [
     "sphinx-rtd-theme",
     "pytest-celery",
     "db-cache-manager>=0.2.2",
-    "elasticsearch-interface>=1.3.0",
+    "elasticsearch-interface>=1.3.1",
     "scikit-learn",
     "opentelemetry-distro==0.40b0",
     "opentelemetry-exporter-otlp==1.19.0",


### PR DESCRIPTION
Fixes bug where non-str, non-list filters were discarded